### PR TITLE
Avoid allocations by inlining functions accepting accumulators

### DIFF
--- a/src/Summation.jl
+++ b/src/Summation.jl
@@ -19,10 +19,10 @@ include("accumulators/compDot.jl")
 # SIAM Journal on Scientific Computing, 6(26), 2005.
 # DOI: 10.1137/030601818
 @generated function accumulate(x::NTuple{A, AbstractArray{T}},
-                                 accType,
+                                 accType::F,
                                  rem_handling = Val(:scalar),
                                  ::Val{Ushift} = Val(2)
-                                 )  where {A, T <: Union{Float32,Float64}, Ushift}
+                                 )  where {F, A, T <: Union{Float32,Float64}, Ushift}
     @assert 0 ≤ Ushift < 6
     U = 1 << Ushift
 
@@ -33,6 +33,7 @@ include("accumulators/compDot.jl")
     V = Vec{W,T}
 
     quote
+        $(Expr(:meta,:inline))
         px = pointer.(x)
         N = length(first(x))
         Base.Cartesian.@nexprs $U u -> begin

--- a/src/accumulators/compDot.jl
+++ b/src/accumulators/compDot.jl
@@ -5,7 +5,7 @@ end
 
 compDotAcc(T) = CompDotAcc{T}(vzero(T), vzero(T))
 
-function add!(acc::CompDotAcc{T}, x::T, y::T) where {T}
+@inline function add!(acc::CompDotAcc{T}, x::T, y::T) where {T}
     SIMDops.@explicit
 
     p, ep = two_prod(x, y)
@@ -13,14 +13,14 @@ function add!(acc::CompDotAcc{T}, x::T, y::T) where {T}
     acc.e += ep + es
 end
 
-function add!(acc::A, x::A) where {A<:CompDotAcc}
+@inline function add!(acc::A, x::A) where {A<:CompDotAcc}
     SIMDops.@explicit
 
     acc.s, e = two_sum(acc.s, x.s)
     acc.e += x.e + e
 end
 
-function Base.sum(acc::CompDotAcc{T}) where {T<:Vec}
+@inline function Base.sum(acc::CompDotAcc{T}) where {T<:Vec}
     acc_r = compDotAcc(fptype(T))
     acc_r.e = vsum(acc.e)
     for xi in acc.s
@@ -30,6 +30,6 @@ function Base.sum(acc::CompDotAcc{T}) where {T<:Vec}
     acc_r
 end
 
-function Base.sum(acc::CompDotAcc{T}) where {T<:Real}
+@inline function Base.sum(acc::CompDotAcc{T}) where {T<:Real}
     acc.s + acc.e
 end

--- a/src/accumulators/compSum.jl
+++ b/src/accumulators/compSum.jl
@@ -3,24 +3,24 @@ mutable struct CompSumAcc{T, EFT}
     e :: T
 end
 
-compSumAcc(EFT) = T->compSumAcc(EFT, T)
-compSumAcc(EFT, T) = CompSumAcc{T, EFT}(vzero(T), vzero(T))
+@inline compSumAcc(EFT) = T->compSumAcc(EFT, T)
+@inline compSumAcc(EFT, T) = CompSumAcc{T, EFT}(vzero(T), vzero(T))
 
-function add!(acc::CompSumAcc{T, EFT}, x::T) where {T, EFT}
+@inline function add!(acc::CompSumAcc{T, EFT}, x::T) where {T, EFT}
     SIMDops.@explicit
 
     acc.s, e = EFT(acc.s, x)
     acc.e += e
 end
 
-function add!(acc::A, x::A) where {A<:CompSumAcc{T, EFT}} where {T, EFT}
+@inline function add!(acc::A, x::A) where {A<:CompSumAcc{T, EFT}} where {T, EFT}
     SIMDops.@explicit
 
     acc.s, e = EFT(acc.s, x.s)
     acc.e += x.e + e
 end
 
-function Base.sum(acc::CompSumAcc{T, EFT}) where {T<:Vec, EFT}
+@inline function Base.sum(acc::CompSumAcc{T, EFT}) where {T<:Vec, EFT}
     acc_r = compSumAcc(EFT, fptype(T))
     acc_r.e = vsum(acc.e)
     for xi in acc.s
@@ -30,6 +30,6 @@ function Base.sum(acc::CompSumAcc{T, EFT}) where {T<:Vec, EFT}
     acc_r
 end
 
-function Base.sum(acc::CompSumAcc{T, EFT}) where {T<:Real, EFT}
+@inline function Base.sum(acc::CompSumAcc{T, EFT}) where {T<:Real, EFT}
     acc.s + acc.e
 end


### PR DESCRIPTION
By preventing the mutable structs from escaping (by inlining all the functions they are passed to as arguments) we avoid allocations and get better performance.

Before PR:
```julia
julia> using AccurateArithmetic, BenchmarkTools

julia> x = rand(1024);

julia> y = rand(1024);

julia> @benchmark sum_kbn($x)
BenchmarkTools.Trial: 
  memory estimate:  592 bytes
  allocs estimate:  5
  --------------
  minimum time:     238.235 ns (0.00% GC)
  median time:      243.833 ns (0.00% GC)
  mean time:        324.037 ns (22.48% GC)
  maximum time:     14.107 μs (96.99% GC)
  --------------
  samples:          10000
  evals/sample:     442

julia> @benchmark sum_oro($x)
BenchmarkTools.Trial: 
  memory estimate:  16 bytes
  allocs estimate:  1
  --------------
  minimum time:     150.962 ns (0.00% GC)
  median time:      152.232 ns (0.00% GC)
  mean time:        156.910 ns (1.02% GC)
  maximum time:     8.306 μs (97.48% GC)
  --------------
  samples:          10000
  evals/sample:     818

julia> @benchmark dot_oro($x,$y)
BenchmarkTools.Trial: 
  memory estimate:  1.16 KiB
  allocs estimate:  9
  --------------
  minimum time:     379.704 ns (0.00% GC)
  median time:      402.424 ns (0.00% GC)
  mean time:        561.343 ns (26.13% GC)
  maximum time:     30.973 μs (97.65% GC)
  --------------
  samples:          10000
  evals/sample:     203
```
after PR:
```julia
julia> using AccurateArithmetic, BenchmarkTools
[ Info: Precompiling AccurateArithmetic [22286c92-06ac-501d-9306-4abd417d9753]

julia> x = rand(1024);

julia> y = rand(1024);

julia> @benchmark sum_kbn($x)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     186.095 ns (0.00% GC)
  median time:      186.521 ns (0.00% GC)
  mean time:        189.388 ns (0.00% GC)
  maximum time:     424.038 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     666

julia> @benchmark sum_oro($x)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     140.254 ns (0.00% GC)
  median time:      140.663 ns (0.00% GC)
  mean time:        142.889 ns (0.00% GC)
  maximum time:     349.425 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     855

julia> @benchmark dot_oro($x,$y)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     219.204 ns (0.00% GC)
  median time:      220.613 ns (0.00% GC)
  mean time:        223.682 ns (0.00% GC)
  maximum time:     479.681 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     501
```

The above tests were run on:
```julia
julia> versioninfo()
Julia Version 1.4.0-DEV.0
Commit 2ef0ed159d* (2019-08-17 17:21 UTC)
Platform Info:
  OS: Linux (x86_64-generic-linux)
  CPU: Intel(R) Core(TM) i9-7900X CPU @ 3.30GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-8.0.0 (ORCJIT, skylake)
```