### PR TITLE
Update compat bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ test = ["BenchmarkTools", "Plots", "Printf", "Statistics", "Test"]
 
 [compat]
 JSON = "0"
-SIMDPirates = "0"
+SIMDPirates = "0.1,0.2,0.3"
 VectorizationBase = "0"
 BenchmarkTools = "0"
 Plots = "0"


### PR DESCRIPTION
incompatibility with SIMDPirates v0.4.0

Should fix gh-11 while we're waiting for an updated version of SIMDPirates