### PR TITLE
Increase SIMDPirates lower bound to 0.2 or above

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 BenchmarkTools = "0"
 JSON = "0"
 Plots = "0"
-SIMDPirates = "0.1, 0.2, 0.3, 0.5, 0.6.3, 0.7"
+SIMDPirates = "0.2, 0.3, 0.5, 0.6.3, 0.7"
 VectorizationBase = "0"
 julia = "1"
 


### PR DESCRIPTION
This is when it started enforcing upper bounds on VectorizationBase, thus guaranteeing compatibility between the two packages. Fixes #11 