### PR TITLE
Mixed precision implementations for operations on single-precision inputs

### DIFF
--- a/src/AccurateArithmetic.jl
+++ b/src/AccurateArithmetic.jl
@@ -11,7 +11,7 @@ export two_sum, two_prod
 
 include("Summation.jl")
 using .Summation
-export sum_naive, sum_kbn, sum_oro
+export sum_naive, sum_kbn, sum_oro, sum_mixed
 export dot_naive, dot_oro
 
 

--- a/src/AccurateArithmetic.jl
+++ b/src/AccurateArithmetic.jl
@@ -12,7 +12,7 @@ export two_sum, two_prod
 include("Summation.jl")
 using .Summation
 export sum_naive, sum_kbn, sum_oro, sum_mixed
-export dot_naive, dot_oro
+export dot_naive, dot_oro, dot_mixed
 
 
 include("Test.jl")

--- a/src/SIMDops.jl
+++ b/src/SIMDops.jl
@@ -10,6 +10,11 @@ fma(x::T, y::T, z::T) where {T<:NTuple} = SIMDPirates.vfma(x, y, z)
 
 fptype(::Type{Vec{W, T}}) where {W, T} = T
 
+# TODO: This probably belong to SIMDPirates
+@inline f64(x::Number)     = Float64(x)
+@inline f64(x::VecElement) = VecElement(f64(x.value))
+@inline f64(x::Vec)        = broadcast(f64, x)
+
 
 # * Macros rewriting mathematical operations
 

--- a/src/Summation.jl
+++ b/src/Summation.jl
@@ -1,6 +1,6 @@
 module Summation
 export sum_naive, sum_kbn, sum_oro, sum_mixed
-export dot_naive, dot_oro
+export dot_naive, dot_oro, dot_mixed
 
 import VectorizationBase
 
@@ -15,6 +15,7 @@ include("accumulators/dot.jl")
 include("accumulators/compSum.jl")
 include("accumulators/compDot.jl")
 include("accumulators/mixedSum.jl")
+include("accumulators/mixedDot.jl")
 
 
 # T. Ogita, S. Rump and S. Oishi, "Accurate sum and dot product",
@@ -95,9 +96,10 @@ end
 # Default values for unrolling
 @inline default_ushift(::SumAcc)      = Val(3)
 @inline default_ushift(::CompSumAcc)  = Val(2)
+@inline default_ushift(::MixedSumAcc) = Val(3)
 @inline default_ushift(::DotAcc)      = Val(3)
 @inline default_ushift(::CompDotAcc)  = Val(2)
-@inline default_ushift(::MixedSumAcc) = Val(2)
+@inline default_ushift(::MixedDotAcc) = Val(3)
 # dispatch
 #   either default_ushift(x,    acc)
 #   or     default_ushift((x,), acc)
@@ -108,9 +110,10 @@ end
 # Default values for cache prefetching
 @inline default_prefetch(::SumAcc)      = Val(0)
 @inline default_prefetch(::CompSumAcc)  = Val(35)
+@inline default_prefetch(::MixedSumAcc) = Val(0)
 @inline default_prefetch(::DotAcc)      = Val(0)
 @inline default_prefetch(::CompDotAcc)  = Val(20)
-@inline default_prefetch(::MixedSumAcc) = Val(0)
+@inline default_prefetch(::MixedDotAcc) = Val(0)
 # dispatch
 #   either default_prefetch(x,    acc)
 #   or     default_prefetch((x,), acc)
@@ -140,5 +143,6 @@ end
 
 dot_naive(x, y) = _dot(x, y, dotAcc)
 dot_oro(x, y)   = _dot(x, y, compDotAcc)
+dot_mixed(x, y) = _dot(x, y, mixedDotAcc)
 
 end

--- a/src/Summation.jl
+++ b/src/Summation.jl
@@ -1,5 +1,5 @@
 module Summation
-export sum_naive, sum_kbn, sum_oro
+export sum_naive, sum_kbn, sum_oro, sum_mixed
 export dot_naive, dot_oro
 
 import VectorizationBase
@@ -14,6 +14,7 @@ include("accumulators/sum.jl")
 include("accumulators/dot.jl")
 include("accumulators/compSum.jl")
 include("accumulators/compDot.jl")
+include("accumulators/mixedSum.jl")
 
 
 # T. Ogita, S. Rump and S. Oishi, "Accurate sum and dot product",
@@ -92,10 +93,11 @@ include("accumulators/compDot.jl")
 end
 
 # Default values for unrolling
-@inline default_ushift(::SumAcc)     = Val(3)
-@inline default_ushift(::CompSumAcc) = Val(2)
-@inline default_ushift(::DotAcc)     = Val(3)
-@inline default_ushift(::CompDotAcc) = Val(2)
+@inline default_ushift(::SumAcc)      = Val(3)
+@inline default_ushift(::CompSumAcc)  = Val(2)
+@inline default_ushift(::DotAcc)      = Val(3)
+@inline default_ushift(::CompDotAcc)  = Val(2)
+@inline default_ushift(::MixedSumAcc) = Val(2)
 # dispatch
 #   either default_ushift(x,    acc)
 #   or     default_ushift((x,), acc)
@@ -104,10 +106,11 @@ end
 
 
 # Default values for cache prefetching
-@inline default_prefetch(::SumAcc)     = Val(0)
-@inline default_prefetch(::CompSumAcc) = Val(35)
-@inline default_prefetch(::DotAcc)     = Val(0)
-@inline default_prefetch(::CompDotAcc) = Val(20)
+@inline default_prefetch(::SumAcc)      = Val(0)
+@inline default_prefetch(::CompSumAcc)  = Val(35)
+@inline default_prefetch(::DotAcc)      = Val(0)
+@inline default_prefetch(::CompDotAcc)  = Val(20)
+@inline default_prefetch(::MixedSumAcc) = Val(0)
 # dispatch
 #   either default_prefetch(x,    acc)
 #   or     default_prefetch((x,), acc)
@@ -125,6 +128,7 @@ end
 sum_naive(x) = _sum(x, sumAcc)
 sum_kbn(x)   = _sum(x, compSumAcc(fast_two_sum))
 sum_oro(x)   = _sum(x, compSumAcc(two_sum))
+sum_mixed(x) = _sum(x, mixedSumAcc)
 
 
 @inline _dot(x, y, acc) = if length(x) < 500

--- a/src/Test.jl
+++ b/src/Test.jl
@@ -63,9 +63,13 @@ function generate_dot(n, c::T; rng=Random.GLOBAL_RNG) where {T}
     d = T(dot(R.(X), R.(Y)))
 
     # Actual condition number
-    c = 2 * dot(abs.(X), abs.(Y)) / abs(d)
+    c_ = 2 * dot(abs.(X), abs.(Y)) / abs(d)
 
-    (X,Y,d,c)
+    if c/10 < c_ < 10c
+        (X,Y,d,c_)
+    else
+        generate_dot(n, c; rng=rng)
+    end
 end
 
 
@@ -103,9 +107,13 @@ function generate_sum(n, c::T; rng=Random.GLOBAL_RNG) where {T}
     s = T(sum(R.(z)))
 
     # Actual condition number
-    c = sum(abs.(z)) / abs(s)
+    c_ = sum(abs.(z)) / abs(s)
 
-    (z, s, c)
+    if c/10 < c_ < 20c
+        (z, s, c_)
+    else
+        generate_sum(n, c; rng=rng)
+    end
 end
 
 end

--- a/src/accumulators/mixedDot.jl
+++ b/src/accumulators/mixedDot.jl
@@ -1,0 +1,17 @@
+mutable struct MixedDotAcc{T}
+    s :: T
+end
+
+mixedDotAcc(::Type{Float32})                   = MixedDotAcc(Float64(0))
+mixedDotAcc(::Type{Vec{N, Float32}}) where {N} = MixedDotAcc(vzero(Vec{N, Float64}))
+
+function add!(acc::MixedDotAcc, x, y)
+    SIMDops.@fusible acc.s += SIMDops.f64(x) * SIMDops.f64(y)
+end
+
+function add!(acc::MixedDotAcc{T}, x::MixedDotAcc{T}) where {T}
+    SIMDops.@fusible acc.s += x.s
+end
+
+Base.sum(acc::MixedDotAcc{T}) where {T<:Vec}  = MixedDotAcc(vsum(acc.s))
+Base.sum(acc::MixedDotAcc{T}) where {T<:Real} = acc.s

--- a/src/accumulators/mixedSum.jl
+++ b/src/accumulators/mixedSum.jl
@@ -1,0 +1,17 @@
+mutable struct MixedSumAcc{T}
+    s :: T
+end
+
+mixedSumAcc(::Type{Float32})                   = MixedSumAcc(Float64(0))
+mixedSumAcc(::Type{Vec{N, Float32}}) where {N} = MixedSumAcc(vzero(Vec{N, Float64}))
+
+function add!(acc::MixedSumAcc, x)
+    SIMDops.@fusible acc.s += SIMDops.f64(x)
+end
+
+function add!(acc::MixedSumAcc{T}, x::MixedSumAcc{T}) where {T}
+    SIMDops.@fusible acc.s += x.s
+end
+
+Base.sum(acc::MixedSumAcc{T}) where {T<:Vec}  = MixedSumAcc(vsum(acc.s))
+Base.sum(acc::MixedSumAcc{T}) where {T<:Real} = acc.s

--- a/src/accumulators/sum.jl
+++ b/src/accumulators/sum.jl
@@ -2,7 +2,7 @@ mutable struct SumAcc{T}
     s :: T
 end
 
-sumAcc(T) = SumAcc{T}(vzero(T))
+sumAcc(T) = SumAcc(vzero(T))
 
 function add!(acc::SumAcc, x)
     SIMDops.@fusible acc.s += x

--- a/test/perftests.jl
+++ b/test/perftests.jl
@@ -15,20 +15,24 @@ output(x) = @printf "%.2e " x
 err(val::T, ref::T) where {T} = min(1, max(eps(T), abs((val-ref)/ref)))
 
 FAST_TESTS = false
+FLOAT_TYPE = Float64
 
 
 
 # * Accuracy
 
+cond_max(::Type{Float64}) = 1e45
+cond_max(::Type{Float32}) = 1f21
+
 function run_accuracy(gen, funs, labels, title, filename)
     println("-> $title")
 
-    n = 100     # Vector size
-    c1 = 2.     # Condition number (min)
-    c2 = 1e45   # -                (max)
-    logstep = 2 # Step for condition number increase (log scale)
+    n = 100                   # Vector size
+    c1 = FLOAT_TYPE(2)        # Condition number (min)
+    c2 = cond_max(FLOAT_TYPE) # -                (max)
+    logstep = 2               # Step for condition number increase (log scale)
 
-    data = [Float64[] for _ in 1:(1+length(funs))]
+    data = [FLOAT_TYPE[] for _ in 1:(1+length(funs))]
 
     c = c1
     while c < c2
@@ -136,23 +140,28 @@ function run_ushift()
     BenchmarkTools.DEFAULT_PARAMETERS.evals = 2
     println("Finding optimal ushift...")
 
-    run_ushift(n->(rand(n),), sumAcc,
+    gen_sum(n) = (rand(FLOAT_TYPE, n),)
+
+    run_ushift(gen_sum, sumAcc,
                "Performance of naive summation",
                "sum_naive_ushift")
 
-    run_ushift(n->(rand(n),), compSumAcc(two_sum),
+    run_ushift(gen_sum, compSumAcc(two_sum),
                "Performance of ORO summation",
                "sum_oro_ushift")
 
-    run_ushift(n->(rand(n),), compSumAcc(fast_two_sum),
+    run_ushift(gen_sum, compSumAcc(fast_two_sum),
                "Performance of KBN summation",
                "sum_kbn_ushift")
 
-    run_ushift(n->(rand(n), rand(n)), dotAcc,
+
+    gen_dot(n) = (rand(FLOAT_TYPE, n), rand(FLOAT_TYPE, n))
+
+    run_ushift(gen_dot, dotAcc,
                "Performance of naive dot product",
                "dot_naive_ushift")
 
-    run_ushift(n->(rand(n), rand(n)), compDotAcc,
+    run_ushift(gen_dot, compDotAcc,
                "Performance of compensated dot product",
                "dot_oro_ushift")
 end
@@ -212,23 +221,28 @@ function run_prefetch()
     BenchmarkTools.DEFAULT_PARAMETERS.evals = 2
     println("Finding optimal prefetch...")
 
-    run_prefetch(n->(rand(n),), sumAcc,
+    gen_sum(n) = (rand(FLOAT_TYPE, n),)
+
+    run_prefetch(gen_sum, sumAcc,
                  "Performance of naive summation",
                  "sum_naive_prefetch")
 
-    run_prefetch(n->(rand(n),), compSumAcc(two_sum),
+    run_prefetch(gen_sum, compSumAcc(two_sum),
                  "Performance of ORO summation",
                  "sum_oro_prefetch")
 
-    run_prefetch(n->(rand(n),), compSumAcc(fast_two_sum),
+    run_prefetch(gen_sum, compSumAcc(fast_two_sum),
                  "Performance of KBN summation",
                  "sum_kbn_prefetch")
 
-    run_prefetch(n->(rand(n), rand(n)), dotAcc,
+
+    gen_dot(n) = (rand(FLOAT_TYPE, n), rand(FLOAT_TYPE, n))
+
+    run_prefetch(gen_dot, dotAcc,
                  "Performance of naive dot product",
                  "dot_naive_prefetch")
 
-    run_prefetch(n->(rand(n), rand(n)), compDotAcc,
+    run_prefetch(gen_dot, compDotAcc,
                  "Performance of compensated dot product",
                  "dot_oro_prefetch")
 end
@@ -273,12 +287,14 @@ function run_performance(n2, gen, funs, labels, title, filename)
         n = max(N, n+32)
     end
 
+    elemsize = sizeof.(eltype.(gen(1))) |> sum
+
     open(filename*".json", "w") do f
         JSON.print(f, Dict(
             :type      => :performance,
             :title     => title,
             :labels    => labels,
-            :elem_size => sizeof(gen(1)),
+            :elem_size => elemsize,
             :data      => data))
     end
 end
@@ -287,14 +303,16 @@ end
 function run_performance()
     println("Running performance tests...")
 
-    run_performance(1e8, n->(rand(n),),
+    gen_sum(n) = (rand(FLOAT_TYPE, n),)
+    run_performance(1e8, gen_sum,
                     (sum,        sum_naive, sum_oro, sum_kbn),
                     ("pairwise", "naive",   "oro",   "kbn"),
                     "Performance of summation implementations",
                     "sum_performance")
 
     BLAS.set_num_threads(1)
-    run_performance(3e7, n->(rand(n), rand(n)),
+    gen_dot(n) = (rand(FLOAT_TYPE, n), rand(FLOAT_TYPE, n))
+    run_performance(3e7, gen_dot,
                     (dot,    dot_naive, dot_oro),
                     ("blas", "naive",   "oro"),
                     "Performance of dot product implementations",
@@ -305,8 +323,14 @@ end
 
 # * All tests
 
-function run_tests(fast=false)
+function run_tests(fast=false, precision=64)
     global FAST_TESTS = fast
+    global FLOAT_TYPE = if precision==64
+        Float64
+    else
+        Float32
+    end
+
     print("Running tests")
     FAST_TESTS && print(" in FAST mode")
     println("...\n")
@@ -322,6 +346,9 @@ function run_tests(fast=false)
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__
+    fast = get(ARGS, 1, "")=="fast"
+    prec = parse(Int, get(ARGS, 2, "64"))
+
     date = open(readline, `git show --no-patch --pretty="%cd" --date="format:%Y-%m-%d.%H%M%S" HEAD`)
     sha1 = open(readline, `git show --no-patch --pretty="%h" HEAD`) |> String
     cpu  = open(read, `lscpu`) |> String
@@ -329,7 +356,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
     cpu  = replace(cpu, r"\(\S+\)" => "")
     cpu  = replace(strip(cpu), r"\s+" => ".")
     blas = BLAS.vendor() |> String
-    jobname = "$(date)_$(sha1)_$(VERSION)_$(cpu)_$(blas)"
+    jobname = "$(date)_$(sha1)_$(VERSION)_$(cpu)_$(blas)_F$(prec)"
     open("jobname", "w") do f
         write(f, jobname)
     end
@@ -340,7 +367,8 @@ if abspath(PROGRAM_FILE) == @__FILE__
             :sha1  => sha1,
             :julia => string(VERSION),
             :cpu   => cpu,
-            :blas  => blas))
+            :blas  => blas,
+            :prec  => prec))
     end
 
     println("\nJob name: $jobname")
@@ -348,6 +376,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
     println("\nJulia version: $VERSION");   println(Base.julia_cmd())
     println("\nCPU: $cpu");                 run(`lscpu`)
     println("\nBLAS vendor: $blas")
+    println("\nFP precision: $prec bits")
 
-    run_tests("fast" in ARGS)
+    run_tests(fast, prec)
 end

--- a/test/perftests.jl
+++ b/test/perftests.jl
@@ -7,7 +7,8 @@ using BenchmarkTools, JSON
 
 using AccurateArithmetic
 using AccurateArithmetic.Summation: accumulate, two_sum, fast_two_sum
-using AccurateArithmetic.Summation: sumAcc, dotAcc, compSumAcc, compDotAcc, mixedSumAcc
+using AccurateArithmetic.Summation: sumAcc, compSumAcc, mixedSumAcc
+using AccurateArithmetic.Summation: dotAcc, compDotAcc, mixedDotAcc
 using AccurateArithmetic.Summation: default_ushift
 using AccurateArithmetic.Test
 
@@ -86,9 +87,14 @@ function run_accuracy()
         (x, y, d, c) = generate_dot(n, c)
         ((x, y), d, c)
     end
-    run_accuracy(gen_dot,
-                 (dot,    dot_naive, dot_oro),
-                 ("blas", "naive",   "oro"),
+
+    funs =   [dot,    dot_naive, dot_oro]
+    labels = ["blas", "naive",   "oro"]
+    if FLOAT_TYPE === Float32
+        push!(funs,   dot_mixed)
+        push!(labels, "mixed")
+    end
+    run_accuracy(gen_dot, funs, labels,
                  "Error of dot product algorithms",
                  "dot_accuracy")
 end
@@ -175,6 +181,12 @@ function run_ushift()
     run_ushift(gen_dot, compDotAcc,
                "Performance of compensated dot product",
                "dot_oro_ushift")
+
+    if FLOAT_TYPE === Float32
+        run_ushift(gen_dot, mixedDotAcc,
+                   "Performance of mixed dot product",
+                   "dot_mixed_ushift")
+    end
 end
 
 
@@ -262,6 +274,12 @@ function run_prefetch()
     run_prefetch(gen_dot, compDotAcc,
                  "Performance of compensated dot product",
                  "dot_oro_prefetch")
+
+    if FLOAT_TYPE === Float32
+        run_prefetch(gen_dot, mixedDotAcc,
+                     "Performance of mixed dot product",
+                     "dot_mixed_prefetch")
+    end
 end
 
 
@@ -333,9 +351,13 @@ function run_performance()
 
     BLAS.set_num_threads(1)
     gen_dot(n) = (rand(FLOAT_TYPE, n), rand(FLOAT_TYPE, n))
-    run_performance(3e7, gen_dot,
-                    (dot,    dot_naive, dot_oro),
-                    ("blas", "naive",   "oro"),
+    funs =   [dot,    dot_naive, dot_oro]
+    labels = ["blas", "naive",   "oro"]
+    if FLOAT_TYPE === Float32
+        push!(funs,   dot_mixed)
+        push!(labels, "mixed")
+    end
+    run_performance(3e7, gen_dot, funs, labels,
                     "Performance of dot product implementations",
                     "dot_performance")
 end

--- a/test/perftests.jl
+++ b/test/perftests.jl
@@ -12,10 +12,19 @@ using AccurateArithmetic.Summation: default_ushift
 using AccurateArithmetic.Test
 
 output(x) = @printf "%.2e " x
-err(val::T, ref::T) where {T} = min(1, max(eps(T), abs((val-ref)/ref)))
+err(val, ref::T) where {T} = min(1, max(eps(T), abs((val-ref)/ref)))
 
 FAST_TESTS = false
 FLOAT_TYPE = Float64
+
+
+function sum_double(x)
+    acc = 0.0
+    @simd for xi in x
+        acc += xi
+    end
+    acc
+end
 
 
 
@@ -71,8 +80,8 @@ function run_accuracy()
         ((x,), d, c)
     end
     run_accuracy(gen_sum,
-                 (sum,        sum_naive, sum_oro, sum_kbn),
-                 ("pairwise", "naive",   "oro",   "kbn"),
+                 (sum,        sum_naive, sum_oro, sum_kbn, sum_double),
+                 ("pairwise", "naive",   "oro",   "kbn",   "double"),
                  "Error of summation algorithms",
                  "sum_accuracy")
 
@@ -305,8 +314,8 @@ function run_performance()
 
     gen_sum(n) = (rand(FLOAT_TYPE, n),)
     run_performance(1e8, gen_sum,
-                    (sum,        sum_naive, sum_oro, sum_kbn),
-                    ("pairwise", "naive",   "oro",   "kbn"),
+                    (sum,        sum_naive, sum_oro, sum_kbn, sum_double),
+                    ("pairwise", "naive",   "oro",   "kbn",   "double"),
                     "Performance of summation implementations",
                     "sum_performance")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using AccurateArithmetic
 using Test
 
 using AccurateArithmetic.Summation: accumulate
-using AccurateArithmetic.Summation: sumAcc, compSumAcc, dotAcc, compDotAcc
+using AccurateArithmetic.Summation: sumAcc, compSumAcc, dotAcc, compDotAcc, mixedSumAcc
 using AccurateArithmetic.Test: generate_sum, generate_dot
 using LinearAlgebra
 using StableRNGs
@@ -14,17 +14,43 @@ using StableRNGs
     @testset "Tests" begin
         @testset "generate_sum" begin
             @testset "vector length" begin
-                for n in 100:110
-                    let (x, s, c_) = generate_sum(n, 1e10; rng=rng)
-                        @test length(x) == n
+                @testset "F64" begin
+                    for n in 100:110
+                        let (x, s, c_) = generate_sum(n, 1e10; rng=rng)
+                            @test eltype(x) === Float64
+                            @test s isa Float64
+                            @test length(x) == n
+                        end
+                    end
+                end
+                @testset "F32" begin
+                    for n in 100:110
+                        let (x, s, c_) = generate_sum(n, 1f5; rng=rng)
+                            @test eltype(x) === Float32
+                            @test s isa Float32
+                            @test length(x) == n
+                        end
                     end
                 end
             end
 
             @testset "condition number" begin
-                for c in (1e10, 1e20)
-                    let (x, s, c_) = generate_sum(101, c; rng=rng)
-                        @test c/100 < c_ < 1000c
+                @testset "F64" begin
+                    for c in (1e10, 1e20)
+                        let (x, s, c_) = generate_sum(101, c; rng=rng)
+                            @test eltype(x) === Float64
+                            @test s isa Float64
+                            @test c/10 < c_ < 20c
+                        end
+                    end
+                end
+                @testset "F32" begin
+                    for c in (1f5, 1f10)
+                        let (x, s, c_) = generate_sum(101, c; rng=rng)
+                            @test eltype(x) === Float32
+                            @test s isa Float32
+                            @test c/10 < c_ < 20c
+                        end
                     end
                 end
             end
@@ -32,18 +58,43 @@ using StableRNGs
 
         @testset "generate_dot" begin
             @testset "vector length" begin
-                for n in 100:110
-                    let (x, y, s, c_) = generate_dot(n, 1e10; rng=rng)
-                        @test length(x) == n
-                        @test length(y) == n
+                @testset "F64" begin
+                    for n in 100:110
+                        let (x, y, s, c_) = generate_dot(n, 1e10; rng=rng)
+                            @test eltype(x) === Float64
+                            @test s isa Float64
+                            @test length(x) == n
+                            @test length(y) == n
+                        end
+                    end
+                end
+                @testset "F32" begin
+                    for n in 100:110
+                        let (x, y, s, c_) = generate_dot(n, 1f5; rng=rng)
+                            @test eltype(x) === Float32
+                            @test s isa Float32
+                            @test length(x) == n
+                            @test length(y) == n
+                        end
                     end
                 end
             end
 
             @testset "condition number" begin
-                for c in (1e10, 1e20)
-                    let (x, y, s, c_) = generate_dot(101, c; rng=rng)
-                        @test c/100 < c_ < 1000c
+                @testset "F64" begin
+                    for c in (1e10, 1e20)
+                        let (x, y, s, c_) = generate_dot(101, c; rng=rng)
+                            @test s isa Float64
+                            @test c/10 < c_ < 10c
+                        end
+                    end
+                end
+                @testset "F32" begin
+                    for c in (1f5, 1f10)
+                        let (x, y, s, c_) = generate_dot(101, c; rng=rng)
+                            @test s isa Float32
+                            @test c/10 < c_ < 10c
+                        end
                     end
                 end
             end
@@ -52,52 +103,127 @@ using StableRNGs
 
     @testset "summation" begin
         @testset "naive" begin
-            for N in 100:110
-                x = rand(rng, N)
-                ref = sum(x)
-                @test ref ≈ sum_naive(x)
+            @testset "F64" begin
+                for N in 100:110
+                    x = rand(rng, N)
+                    ref = sum(x)
+                    @test ref isa Float64
+                    @test ref ≈ sum_naive(x)
 
-                acc = sumAcc
-                @test ref ≈ accumulate((x,), acc, Val(:scalar), Val(2))
-                @test ref ≈ accumulate((x,), acc, Val(:mask),   Val(2))
+                    acc = sumAcc
+                    @test ref ≈ accumulate((x,), acc, Val(:scalar), Val(2))
+                    @test ref ≈ accumulate((x,), acc, Val(:mask),   Val(2))
+                end
+            end
+            @testset "F32" begin
+                for N in 100:110
+                    x = rand(rng, Float32, N)
+                    ref = sum(x)
+                    @test ref isa Float32
+                    @test ref ≈ sum_naive(x)
+
+                    acc = sumAcc
+                    @test ref ≈ accumulate((x,), acc, Val(:scalar), Val(2))
+                    @test ref ≈ accumulate((x,), acc, Val(:mask),   Val(2))
+                end
             end
         end
 
         @testset "compensated" begin
-            for N in 100:110
-                x, ref, _ = generate_sum(N, 1e10; rng=rng)
-                @test ref == sum_oro(x)
-                @test ref == sum_kbn(x)
+            @testset "F64" begin
+                for N in 100:110
+                    x, ref, _ = generate_sum(N, 1e10; rng=rng)
+                    @test ref isa Float64
+                    @test ref == sum_oro(x)
+                    @test ref == sum_kbn(x)
 
-                acc = compSumAcc(two_sum)
-                @test ref == accumulate((x,), acc, Val(:scalar), Val(2))
-                @test ref == accumulate((x,), acc, Val(:mask),   Val(2))
+                    acc = compSumAcc(two_sum)
+                    @test ref == accumulate((x,), acc, Val(:scalar), Val(2))
+                    @test ref == accumulate((x,), acc, Val(:mask),   Val(2))
+                end
+            end
+            @testset "F32" begin
+                for N in 100:110
+                    x, ref, _ = generate_sum(N, 1f4; rng=rng)
+                    @test ref isa Float32
+                    @test ref == sum_oro(x)
+                    @test ref == sum_kbn(x)
+
+                    acc = compSumAcc(two_sum)
+                    @test ref == accumulate((x,), acc, Val(:scalar), Val(2))
+                    @test ref == accumulate((x,), acc, Val(:mask),   Val(2))
+                end
+            end
+        end
+
+        @testset "mixed" begin
+            for N in 100:110
+                # Only test for approximate equality here, since sum_mixed
+                # returns a Float64 whereas the reference value is a Float32
+
+                x, ref, _ = generate_sum(N, 1f7; rng=rng)
+                @test ref isa Float32
+                @test ref ≈ sum_mixed(x)
+
+                acc = mixedSumAcc
+                @test ref ≈ accumulate((x,), acc, Val(:scalar), Val(2))
+                @test ref ≈ accumulate((x,), acc, Val(:mask),   Val(2))
             end
         end
     end
 
     @testset "dot product" begin
         @testset "naive" begin
-            for N in 100:110
-                x = rand(rng, N)
-                y = rand(rng, N)
-                ref = dot(x, y)
-                @test ref ≈ dot_naive(x, y)
+            @testset "F64" begin
+                for N in 100:110
+                    x = rand(rng, N)
+                    y = rand(rng, N)
+                    ref = dot(x, y)
+                    @test ref isa Float64
+                    @test ref ≈ dot_naive(x, y)
 
-                acc = dotAcc
-                @test ref ≈ accumulate((x,y), acc, Val(:scalar), Val(2))
-                @test ref ≈ accumulate((x,y), acc, Val(:mask),   Val(2))
+                    acc = dotAcc
+                    @test ref ≈ accumulate((x,y), acc, Val(:scalar), Val(2))
+                    @test ref ≈ accumulate((x,y), acc, Val(:mask),   Val(2))
+                end
+            end
+            @testset "F32" begin
+                for N in 100:110
+                    x = rand(rng, Float32, N)
+                    y = rand(rng, Float32, N)
+                    ref = dot(x, y)
+                    @test ref isa Float32
+                    @test ref ≈ dot_naive(x, y)
+
+                    acc = dotAcc
+                    @test ref ≈ accumulate((x,y), acc, Val(:scalar), Val(2))
+                    @test ref ≈ accumulate((x,y), acc, Val(:mask),   Val(2))
+                end
             end
         end
 
         @testset "compensated" begin
-            for N in 100:110
-                x, y, ref, _ = generate_dot(N, 1e10; rng=rng)
-                @test ref == dot_oro(x, y)
+            @testset "F64" begin
+                for N in 100:110
+                    x, y, ref, _ = generate_dot(N, 1e10; rng=rng)
+                    @test ref isa Float64
+                    @test ref == dot_oro(x, y)
 
-                acc = compDotAcc
-                @test ref == accumulate((x,y), acc, Val(:scalar), Val(2))
-                @test ref == accumulate((x,y), acc, Val(:mask),   Val(2))
+                    acc = compDotAcc
+                    @test ref == accumulate((x,y), acc, Val(:scalar), Val(2))
+                    @test ref == accumulate((x,y), acc, Val(:mask),   Val(2))
+                end
+            end
+            @testset "F32" begin
+                for N in 100:110
+                    x, y, ref, _ = generate_dot(N, 1f4; rng=rng)
+                    @test ref isa Float32
+                    @test ref == dot_oro(x, y)
+
+                    acc = compDotAcc
+                    @test ref == accumulate((x,y), acc, Val(:scalar), Val(2))
+                    @test ref == accumulate((x,y), acc, Val(:mask),   Val(2))
+                end
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,7 @@ using StableRNGs
                         let (x, s, c_) = generate_sum(101, c; rng=rng)
                             @test eltype(x) === Float64
                             @test s isa Float64
-                            @test c/10 < c_ < 20c
+                            @test c/3 < c_ < 3c
                         end
                     end
                 end
@@ -50,7 +50,7 @@ using StableRNGs
                         let (x, s, c_) = generate_sum(101, c; rng=rng)
                             @test eltype(x) === Float32
                             @test s isa Float32
-                            @test c/10 < c_ < 20c
+                            @test c/3 < c_ < 3c
                         end
                     end
                 end
@@ -86,7 +86,7 @@ using StableRNGs
                     for c in (1e10, 1e20)
                         let (x, y, s, c_) = generate_dot(101, c; rng=rng)
                             @test s isa Float64
-                            @test c/10 < c_ < 10c
+                            @test c/3 < c_ < 3c
                         end
                     end
                 end
@@ -94,7 +94,7 @@ using StableRNGs
                     for c in (1f5, 1f10)
                         let (x, y, s, c_) = generate_dot(101, c; rng=rng)
                             @test s isa Float32
-                            @test c/10 < c_ < 10c
+                            @test c/3 < c_ < 3c
                         end
                     end
                 end
@@ -145,7 +145,7 @@ using StableRNGs
             end
             @testset "F32" begin
                 for N in 100:110
-                    x, ref, _ = generate_sum(N, 1f4; rng=rng)
+                    x, ref, _ = generate_sum(N, 1f5; rng=rng)
                     @test ref isa Float32
                     @test ref == sum_oro(x)
                     @test ref == sum_kbn(x)
@@ -217,7 +217,7 @@ using StableRNGs
             end
             @testset "F32" begin
                 for N in 100:110
-                    x, y, ref, _ = generate_dot(N, 1f4; rng=rng)
+                    x, y, ref, _ = generate_dot(N, 1f5; rng=rng)
                     @test ref isa Float32
                     @test ref == dot_oro(x, y)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,8 @@ using AccurateArithmetic
 using Test
 
 using AccurateArithmetic.Summation: accumulate
-using AccurateArithmetic.Summation: sumAcc, compSumAcc, dotAcc, compDotAcc, mixedSumAcc
+using AccurateArithmetic.Summation: sumAcc, compSumAcc, mixedSumAcc
+using AccurateArithmetic.Summation: dotAcc, compDotAcc, mixedDotAcc
 using AccurateArithmetic.Test: generate_sum, generate_dot
 using LinearAlgebra
 using StableRNGs
@@ -224,6 +225,21 @@ using StableRNGs
                     @test ref == accumulate((x,y), acc, Val(:scalar), Val(2))
                     @test ref == accumulate((x,y), acc, Val(:mask),   Val(2))
                 end
+            end
+        end
+
+        @testset "mixed" begin
+            for N in 100:110
+                # Only test for approximate equality here, since dot_mixed
+                # returns a Float64 whereas the reference value is a Float32
+
+                x, y, ref, _ = generate_dot(N, 1f7; rng=rng)
+                @test ref isa Float32
+                @test ref ≈ dot_mixed(x, y)
+
+                acc = mixedDotAcc
+                @test ref ≈ accumulate((x,y), acc, Val(:scalar), Val(2))
+                @test ref ≈ accumulate((x,y), acc, Val(:mask),   Val(2))
             end
         end
     end


### PR DESCRIPTION
Most of what I wanted to explore with Float32 is now done, which is why I'm opening this as a draft PR to let anyone interested have a look at it and comment if necessary. I'm planning to release this as v0.3.5 when it's done.

Here is a list of the changes (to be) included in this PR:
- [X] optimized, vectorized, mixed-precision implementation of sums and dot products relying on the use of a Float64 accumulator for Float32 inputs: `sum_mixed` and `dot_mixed`;
- [X] inclusion of Float32 inputs in all verification tests;
- [X] possibility to run performance tests on 32-bit inputs; a collateral benefit of this work is that the generation of input data for sums and dot products with a given condition number is now much more reliable;
- [x] updated README advertising these new features.

I'm still in the process of testing the performance of `dot_mixed`, but my first conclusions are:
- mixed-precision implementations are always faster than compensated ones; they should be the preferred choice to get additional accuracy with Float32 inputs;
- mixed-precision implementations are even almost as fast as naive implementations on AVX512 systems; we could probably even go as far as suggesting that mixed implementations be used by default (*i.e.* in `Base.sum` or `LinearAlgebra.dot`) when working with Float32 inputs on newer or high-end systems;
- I'm thinking of perhaps introducing single, high-level entry points that would dispatch on the most efficient accurate implementation based on the input element types and the CPU being used. These new entry points could be unexported functions with common names (*e.g.* `AccurateArithmetic.sum` and `AccurateArithmetic.dot`) that users would need to use explicitly. Or they could be exported functions with specific names (like `accurate_sum` and `accurate_dot`).